### PR TITLE
Add "verbatim" option to subscribe function

### DIFF
--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -193,7 +193,12 @@ function subscribe( channelName, channel, topology, messages, options ) {
 	log.info( 'Starting subscription %s - %s', channelName, topology.connection.name );
 	return channel.consume( channelName, function( raw ) {
 		var correlationId = raw.properties.correlationId;
-		raw.body = JSON.parse( raw.content.toString( 'utf8' ) );
+		var contentString = raw.content.toString( 'utf8' );
+		if ( options.verbatim ) {
+			raw.body = contentString;
+		} else {
+			raw.body = JSON.parse( contentString );
+		}
 
 		var ops = getResolutionOperations( channel, raw, messages, options );
 


### PR DESCRIPTION
see https://github.com/LeanKit-Labs/wascally/pull/106

This allows non-JSON messages to be consumed by adding a line to the
queue's JSON configuration:

```
   queues: [
     {
       name: queueName,
+      verbatim: true,
       autoDelete: true,
       subscribe: true,
     }
   ],
```
